### PR TITLE
allow to set different exposure times for each of the sensors

### DIFF
--- a/include/mynteyed/camera.h
+++ b/include/mynteyed/camera.h
@@ -183,6 +183,11 @@ class MYNTEYE_API Camera {
    * value -- exposure time value
    * */
   void SetExposureTime(const float &value);
+  /** Set exposure time [1ms - 2000ms]
+   * value -- exposure time value
+   * sensor -- SensorMode::ALL, LEFT, RIGHT
+   * */
+  void SetExposureTime(const float &value, const SensorMode &sensor);
   /** Get exposure time
    * value -- return exposure time value
    * */

--- a/src/mynteyed/camera.cc
+++ b/src/mynteyed/camera.cc
@@ -217,6 +217,10 @@ void Camera::SetExposureTime(const float &value) {
   return p_->SetExposureTime(value);
 }
 
+void Camera::SetExposureTime(const float &value, const SensorMode &sensor) {
+  return p_->SetExposureTime(value, sensor);
+}
+
 void Camera::GetExposureTime(float &value) {
   return p_->GetExposureTime(value);
 }

--- a/src/mynteyed/device/device.cc
+++ b/src/mynteyed/device/device.cc
@@ -1123,6 +1123,10 @@ bool Device::SetSensorType(const SensorType &type) {
 }
 
 bool Device::SetExposureTime(const float &value) {
+  SetExposureTime(value, SensorMode::ALL);
+}
+
+bool Device::SetExposureTime(const float &value, const SensorMode &sensor) {
   if (!IsOpened()) {
     LOGE("\nERROR:: Device is not opened.\n");
     return false;
@@ -1130,7 +1134,7 @@ bool Device::SetExposureTime(const float &value) {
   if (!SetSensorType(SensorType::SENSOR_TYPE_AR0135))
     return false;
 
-  int sensor_mode = get_sensor_mode(SensorMode::ALL);
+  int sensor_mode = get_sensor_mode(sensor);
   if (EtronDI_SetExposureTime(
         handle_, &dev_sel_info_,
         sensor_mode, value) == ETronDI_OK) {

--- a/src/mynteyed/device/device.h
+++ b/src/mynteyed/device/device.h
@@ -120,6 +120,11 @@ class Device {
    * value -- exposure time value
    * */
   bool SetExposureTime(const float &value);
+  /** Set exposure time
+   * value -- exposure time value
+   * sensor -- ALL, LEFT, RIGHT
+   * */
+  bool SetExposureTime(const float &value, const SensorMode &sensor);
   /** Get exposure time
    * value -- return exposure time value
    * */

--- a/src/mynteyed/internal/camera_p.cc
+++ b/src/mynteyed/internal/camera_p.cc
@@ -521,6 +521,10 @@ void CameraPrivate::SetExposureTime(const float &value) {
   device_->SetExposureTime(value);
 }
 
+void CameraPrivate::SetExposureTime(const float &value, const SensorMode &sensor) {
+  device_->SetExposureTime(value, sensor);
+}
+
 void CameraPrivate::GetExposureTime(float &value) {
   device_->GetExposureTime(value);
 }

--- a/src/mynteyed/internal/camera_p.h
+++ b/src/mynteyed/internal/camera_p.h
@@ -176,6 +176,11 @@ class MYNTEYE_API CameraPrivate {
    * value -- exposure time value
    * */
   void SetExposureTime(const float &value);
+  /** Set exposure time
+   * value -- exposure time value
+   * sensor -- SensorMode::ALL, LEFT, RIGHT
+   * */
+  void SetExposureTime(const float &value, const SensorMode &sensor);
   /** Get exposure time
    * value -- return exposure time value
    * */


### PR DESCRIPTION
Addition to Camera, Camera_P and Device classes to allow setting different exposure times for LEFT and RIGHT sensors

Here is an example of how to use it

```
  float exposure_left = 10.f; // 1-655ms
  float exposure_right = 1.f; // 1-655ms

  cam.AutoExposureControl(false);
  cam.SetExposureTime(exposure_left, SensorMode::LEFT);
  cam.SetExposureTime(exposure_right, SensorMode::RIGHT);
```

Keeps backwards compatibility