### PR TITLE
camera_info header missing frame_id

### DIFF
--- a/wrappers/ros/src/mynteye_wrapper_d/src/mynteye_wrapper_nodelet.cc
+++ b/wrappers/ros/src/mynteye_wrapper_d/src/mynteye_wrapper_nodelet.cc
@@ -608,7 +608,10 @@ class MYNTEYEWrapperNodelet : public nodelet::Nodelet {
       header.frame_id = color_frame_id;
 
       auto&& msg = cv_bridge::CvImage(header, enc::BGR8, mat).toImageMsg();
-      if (info) info->header.stamp = msg->header.stamp;
+      if (info) {
+        info->header.stamp = msg->header.stamp;
+        info->header.frame_id = color_frame_id;
+      }
       pub_color.publish(msg, info);
     }
     if (mono_sub) {


### PR DESCRIPTION
It looks like the frame id was missing from the header of the camera info as the frame_id was only added to the camera topic itself but not to the header of the info object passed as an argument.