### PR TITLE
Fix infinite init

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,3 +332,13 @@ install(EXPORT mynteyed-targets
 # summary
 
 include(${MYNTEYE_ROOT}/cmake/Summary.cmake)
+
+
+set(CPACK_GENERATOR "DEB")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Blue ocean obotics.")
+set(CPACK_PACKAGE_VERSION ${VERSION})
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "MYNT eye D library.")
+set(CPACK_PACKAGE_DESCRIPTION "Camera library for MYNTEYE D.")
+set(CPACK_DEBIAN_PACKAGE_SECTION "Development")
+
+include(CPack)

--- a/wrappers/ros/src/mynteye_wrapper_d/launch/mynteye_nodelet.launch
+++ b/wrappers/ros/src/mynteye_wrapper_d/launch/mynteye_nodelet.launch
@@ -1,0 +1,206 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- Device mode -->
+  <arg name="device_color"      default="0" />
+  <arg name="device_depth"      default="1" />
+  <arg name="device_all"        default="2" />
+  <!-- Color mode -->
+  <arg name="color_raw"         default="0" />
+  <arg name="color_rectified"   default="1" />
+  <!-- Depth mode -->
+  <arg name="depth_raw"         default="0" />
+  <arg name="depth_gray"        default="1" />
+  <arg name="depth_colorful"    default="2" />
+  <!-- Stream mode -->
+  <arg name="stream_640x480"    default="0" />
+  <arg name="stream_1280x480"   default="1" />
+  <arg name="stream_1280x720"   default="2" />
+  <arg name="stream_2560x720"   default="3" />
+  <!-- Stream format -->
+  <arg name="stream_mjpg"       default="0" />
+  <arg name="stream_yuyv"       default="1" />
+
+  <!-- 0 --> MONO16 -->
+  <!-- 1 --> TYPE_16UC1 -->
+  <arg name="type_mono16"        default="0" />
+  <arg name="type_16uc1"         default="1" />
+
+  <!-- IMU timestamp align -->
+  <arg name="imu_timestamp_align" default="true" />
+
+  <!-- Camera Params -->
+
+  <!-- Device index -->
+  <arg name="dev_index" default="0" />
+  <!-- Framerate -->
+  <arg name="framerate" default="30" />
+
+  <!--
+  Device mode
+    device_color: left_color ✓ right_color ? depth x
+    device_depth: left_color x right_color x depth ✓
+    device_all:   left_color ✓ right_color ? depth ✓
+  Note: ✓: available, x: unavailable, ?: depends on #stream_mode
+  -->
+  <arg name="dev_mode" default="$(arg device_all)" />
+
+  <arg name="color_mode" default="$(arg color_raw)" />
+  <!-- Note: must set DEPTH_RAW to get raw depth values for points -->
+  <arg name="depth_mode" default="$(arg depth_raw)" />
+  <arg name="stream_mode" default="$(arg stream_2560x720)" />
+  <arg name="color_stream_format" default="$(arg stream_yuyv)" />
+  <arg name="depth_stream_format" default="$(arg stream_yuyv)" />
+  <arg name="depth_type" default="$(arg type_mono16)" />
+
+  <!-- Auto-exposure -->
+  <arg name="state_ae" default="true" />
+  <!-- Auto-white balance -->
+  <arg name="state_awb" default="true" />
+  <!-- IR intensity -->
+  <arg name="ir_intensity" default="4" />
+  <!-- IR Depth Only -->
+  <arg name="ir_depth_only" default="false" />
+
+  <!-- Generating points frequency, make slower than framerate -->
+  <arg name="points_frequency" default="10" />
+  <!-- Points display z distance scale factor -->
+  <arg name="points_factor" default="1000.0" />
+
+  <!-- Setup your local gravity here -->
+  <arg name="gravity" default="9.8" />
+
+  <!-- Node params -->
+
+  <arg name="mynteye"       default="mynteye" />
+  <arg name="base_frame"    default="$(arg mynteye)_link_frame" />
+
+  <arg name="left_mono_frame"   default="$(arg mynteye)_left_mono_frame" />
+  <arg name="left_color_frame"  default="$(arg mynteye)_left_color_frame" />
+  <arg name="right_mono_frame"  default="$(arg mynteye)_right_mono_frame" />
+  <arg name="right_color_frame" default="$(arg mynteye)_right_color_frame" />
+  <arg name="depth_frame"   default="$(arg mynteye)_depth_frame" />
+  <arg name="points_frame"  default="$(arg mynteye)_points_frame" />
+  <arg name="imu_frame"     default="$(arg mynteye)_imu_frame" />
+  <arg name="temp_frame"    default="$(arg mynteye)_temp_frame" />
+  <arg name="imu_frame_processed"     default="$(arg mynteye)_imu_frame_processed" />
+
+  <!-- left topics -->
+  <arg name="left_mono_topic"  default="$(arg mynteye)/left/image_mono" />
+  <arg name="left_color_topic" default="$(arg mynteye)/left/image_color" />
+  <!-- right topics -->
+  <arg name="right_mono_topic"  default="$(arg mynteye)/right/image_mono" />
+  <arg name="right_color_topic" default="$(arg mynteye)/right/image_color" />
+  <!-- depth topic -->
+  <arg name="depth_topic"   default="$(arg mynteye)/depth/image_raw" />
+  <!-- points topic -->
+  <arg name="points_topic"  default="$(arg mynteye)/points/data_raw" />
+  <!-- imu topic origin -->
+  <arg name="imu_topic"     default="$(arg mynteye)/imu/data_raw" />
+  <!-- temp topic -->
+  <arg name="temp_topic"    default="$(arg mynteye)/temp/data_raw" />
+  <!-- imu topic processed -->
+  <arg name="imu_processed_topic"     default="$(arg mynteye)/imu/data_raw_processed" />
+
+  <arg name="pi"   value="3.1415926535897932" />
+  <arg name="pi/2" value="1.5707963267948966" />
+  <arg name="optical_rotate" value="0 0 0 -$(arg pi/2) 0 -$(arg pi/2)" />
+
+  <node pkg="tf" type="static_transform_publisher" name="b2l_m_broadcaster"
+      args="$(arg optical_rotate) $(arg base_frame) $(arg left_mono_frame) 100" />
+  <node pkg="tf" type="static_transform_publisher" name="b2l_c_broadcaster"
+      args="$(arg optical_rotate) $(arg base_frame) $(arg left_color_frame) 100" />
+
+  <node pkg="tf" type="static_transform_publisher" name="b2r_m_broadcaster"
+      args="$(arg optical_rotate) $(arg base_frame) $(arg right_mono_frame) 100" />
+  <node pkg="tf" type="static_transform_publisher" name="b2r_c_broadcaster"
+      args="$(arg optical_rotate) $(arg base_frame) $(arg right_color_frame) 100" />
+
+  <node pkg="tf" type="static_transform_publisher" name="b2d_broadcaster"
+      args="$(arg optical_rotate) $(arg base_frame) $(arg depth_frame) 100" />
+  <node pkg="tf" type="static_transform_publisher" name="b2p_broadcaster"
+      args="$(arg optical_rotate) $(arg base_frame) $(arg points_frame) 100" />
+
+  <node pkg="tf" type="static_transform_publisher" name="b2imu_broadcaster"
+      args="0 0 0 $(arg pi/2) 0 $(arg pi) $(arg base_frame) $(arg imu_frame) 50" />
+  <node pkg="tf" type="static_transform_publisher" name="b2temp_broadcaster"
+      args="0 0 0 $(arg pi/2) 0 $(arg pi) $(arg base_frame) $(arg temp_frame) 50" />
+  <node pkg="tf" type="static_transform_publisher" name="b2imu_processed_broadcaster"
+      args="0 0 0 $(arg pi/2) 0 $(arg pi) $(arg base_frame) $(arg imu_frame_processed) 50" />
+  
+  <arg name="mesh_file" default="D-0315.obj" />
+
+<node pkg="nodelet" type="nodelet" name="nodelet_manager"  args="manager" output="screen"/>
+
+<node pkg="nodelet" type="nodelet" name="nodelet_mynteye" args="load mynteye_wrapper_d/MYNTEYEWrapperNodelet nodelet_manager" output="screen">
+
+    <!-- Camera params -->
+    <param name="dev_index"     value="$(arg dev_index)" />
+    <param name="framerate"     value="$(arg framerate)" />
+    <param name="dev_mode"      value="$(arg dev_mode)" />
+    <param name="color_mode"    value="$(arg color_mode)" />
+    <param name="depth_mode"    value="$(arg depth_mode)" />
+    <param name="stream_mode"   value="$(arg stream_mode)" />
+    <param name="color_stream_format" value="$(arg color_stream_format)" />
+    <param name="depth_stream_format" value="$(arg depth_stream_format)" />
+    <param name="state_ae"      value="$(arg state_ae)" />
+    <param name="state_awb"     value="$(arg state_awb)" />
+    <param name="ir_intensity"  value="$(arg ir_intensity)" />
+    <param name="ir_depth_only" value="$(arg ir_depth_only)" />
+    <param name="imu_timestamp_align" value="$(arg imu_timestamp_align)" />
+
+    <param name="points_factor"    value="$(arg points_factor)" />
+    <param name="points_frequency" value="$(arg points_frequency)" />
+
+    <param name="gravity" value="$(arg gravity)" />
+
+    <param name="depth_type" value="$(arg type_mono16)" />
+
+    <!-- Frame ids -->
+    <param name="base_frame"   value="$(arg base_frame)" />
+    <param name="left_mono_frame"   value="$(arg left_mono_frame)" />
+    <param name="left_color_frame"  value="$(arg left_color_frame)" />
+    <param name="right_mono_frame"  value="$(arg right_mono_frame)" />
+    <param name="right_color_frame" value="$(arg right_color_frame)" />
+    <param name="depth_frame"  value="$(arg depth_frame)" />
+    <param name="points_frame" value="$(arg points_frame)" />
+    <param name="imu_frame"    value="$(arg imu_frame)" />
+    <param name="temp_frame"   value="$(arg temp_frame)" />
+    <param name="imu_frame_processed"    value="$(arg imu_frame_processed)" />
+
+    <!-- Topic names -->
+
+    <param name="left_mono_topic"   value="$(arg left_mono_topic)" />
+    <param name="left_color_topic"  value="$(arg left_color_topic)" />
+    <param name="right_mono_topic"  value="$(arg right_mono_topic)" />
+    <param name="right_color_topic" value="$(arg right_color_topic)" />
+    <param name="depth_topic"       value="$(arg depth_topic)" />
+    <param name="points_topic"      value="$(arg points_topic)" />
+    <param name="imu_topic"         value="$(arg imu_topic)" />
+    <param name="temp_topic"        value="$(arg temp_topic)" />
+    <param name="imu_processed_topic"         value="$(arg imu_processed_topic)" />
+
+    <param name="mesh_file" value="$(arg mesh_file)" />
+</node>
+
+  <!-- disable compressed depth plugin for image topics -->
+  <group ns="$(arg left_mono_topic)">
+    <rosparam param="disable_pub_plugins">
+      - 'image_transport/compressedDepth'
+    </rosparam>
+  </group>
+  <group ns="$(arg left_color_topic)">
+    <rosparam param="disable_pub_plugins">
+      - 'image_transport/compressedDepth'
+    </rosparam>
+  </group>
+  <group ns="$(arg right_mono_topic)">
+    <rosparam param="disable_pub_plugins">
+      - 'image_transport/compressedDepth'
+    </rosparam>
+  </group>
+  <group ns="$(arg right_color_topic)">
+    <rosparam param="disable_pub_plugins">
+      - 'image_transport/compressedDepth'
+    </rosparam>
+  </group>
+</launch>

--- a/wrappers/ros/src/mynteye_wrapper_d/src/mynteye_wrapper_nodelet.cc
+++ b/wrappers/ros/src/mynteye_wrapper_d/src/mynteye_wrapper_nodelet.cc
@@ -98,6 +98,8 @@ class MYNTEYEWrapperNodelet : public nodelet::Nodelet {
   ros::Publisher pub_imu_processed;
   ros::Publisher pub_mesh_;  // < The publisher for camera mesh.
 
+  ros::Timer timer_;
+
   visualization_msgs::Marker mesh_msg_;  // < Mesh message.
   ros::ServiceServer get_params_service_;
 
@@ -341,6 +343,10 @@ class MYNTEYEWrapperNodelet : public nodelet::Nodelet {
 
     mynteye->EnableProcessMode(ProcessMode::PROC_NONE);
 
+    // timer to update nodelet
+    ros::Duration timer_period(1.0 / framerate);
+    timer_ = nh_ns.createTimer(timer_period, boost::bind(&MYNTEYEWrapperNodelet::updateCb, this, _1));
+
     // Image publishers
 
     image_transport::ImageTransport it_mynteye(nh);
@@ -373,15 +379,13 @@ class MYNTEYEWrapperNodelet : public nodelet::Nodelet {
     detectSubscribers();
     // open device
     openDevice();
-
-    // loop
-    ros::Rate loop_rate(framerate);
-    while (nh_ns.ok()) {
-      publishMesh();
-      detectSubscribers();
-      loop_rate.sleep();
-    }
   }
+
+  void updateCb(const ros::TimerEvent& event){
+    publishMesh();
+    detectSubscribers();
+  }
+
 
   void detectSubscribers() {
     bool left_mono_sub = pub_left_mono.getNumSubscribers() > 0;


### PR DESCRIPTION
- While trying to run the ros wrapper as a nodeled, with more nodelets attached to it, I've noticed that the rest of nodelets did not start. This was caused because there was a ros::spin in the init(). Hence, that never finished, and the nodeled manager could not start other nodeleds.

To have the same behavior I created a timer that behaves like the spin but without blocking the whole process. I tested it with mynteye P. Both nodeled and node works!